### PR TITLE
Add JupyterBook v2 + JupyterLite Template to gallery

### DIFF
--- a/docs/src/gallery.yml
+++ b/docs/src/gallery.yml
@@ -12,13 +12,13 @@
   description: A GitHub Template repository designed for use in Jupyter Book 2 and MyST workshops.
   tags: JupyterBook; Tutorial
 
-- name: JupyterBook v2 + JupyterLite Template
+- name: Jupyter Book Template with Editable Pyodide Code Cells
   website: https://chandraveshchaudhari.github.io/jupyterbook2_with_lite_template/
   repository: https://github.com/chandraveshchaudhari/jupyterbook2_with_lite_template
   image: https://raw.githubusercontent.com/chandraveshchaudhari/jupyterbook2_with_lite_template/main/media/images/banner_image.png
-  description: A GitHub template for Jupyter Book v2 (MyST) with in-page Python editor with syntax highlighting using JupyterLite and Pyodide.
-  tags: JupyterBook; Template; JupyterLite; Pyodide
-
+  description: A Jupyter Book v2 (MyST) template with editable, syntax-highlighted Python code cells powered by JupyterLite (Pyodide), enabling client-side execution in the browser without a backend, including offline use after initial load.
+  tags: JupyterBook; Template; JupyterLite; Pyodide; Interactive; Offline
+  
 - name: The Turing Way handbook to reproducible, ethical and collaborative data science.
   website: https://book.the-turing-way.org/
   repository: https://github.com/the-turing-way/the-turing-way

--- a/docs/src/gallery.yml
+++ b/docs/src/gallery.yml
@@ -12,6 +12,13 @@
   description: A GitHub Template repository designed for use in Jupyter Book 2 and MyST workshops.
   tags: JupyterBook; Tutorial
 
+- name: JupyterBook v2 + JupyterLite Template
+  website: https://chandraveshchaudhari.github.io/jupyterbook2_with_lite_template/
+  repository: https://github.com/chandraveshchaudhari/jupyterbook2_with_lite_template
+  image: https://raw.githubusercontent.com/chandraveshchaudhari/jupyterbook2_with_lite_template/main/media/images/banner_image.png
+  description: A GitHub template for Jupyter Book v2 (MyST) with in-page Python editor with syntax highlighting using JupyterLite and Pyodide.
+  tags: JupyterBook; Template; JupyterLite; Pyodide
+
 - name: The Turing Way handbook to reproducible, ethical and collaborative data science.
   website: https://book.the-turing-way.org/
   repository: https://github.com/the-turing-way/the-turing-way


### PR DESCRIPTION
Added a detailed entry for the JupyterBook v2 + JupyterLite template. This template is built on JupyterBook v2 (MyST) and supports interactive Pyodide-powered code cells, enabling Python execution entirely in the browser through WebAssembly—no backend or server required. All computation runs client-side, making it fully compatible with GitHub Pages deployment. Additionally, it features an in-browser code editor with syntax highlighting, allowing users to modify and experiment with code directly on the page, even in offline or browser-only environments.