### PR TITLE
add uc ospo network to gallery

### DIFF
--- a/docs/src/gallery.yml
+++ b/docs/src/gallery.yml
@@ -18,7 +18,7 @@
   image: https://raw.githubusercontent.com/chandraveshchaudhari/jupyterbook2_with_lite_template/main/media/images/banner_image.png
   description: A Jupyter Book v2 (MyST) template with editable, syntax-highlighted Python code cells powered by JupyterLite (Pyodide), enabling client-side execution in the browser without a backend, including offline use after initial load.
   tags: JupyterBook; Template; JupyterLite; Pyodide; Interactive; Offline
-  
+
 - name: The Turing Way handbook to reproducible, ethical and collaborative data science.
   website: https://book.the-turing-way.org/
   repository: https://github.com/the-turing-way/the-turing-way
@@ -123,7 +123,7 @@
   image: https://raw.githubusercontent.com/microsoft/PyRIT/refs/heads/main/doc/roakey.png
   description: The guide for the PyRIT open source framework built to empower security professionals and engineers to proactively identify risks in generative AI systems.
   tags: Python; AI Red Teaming; AI Security; AI Safety;
-  
+
 - name: Introduction to GIS Programming
   website: https://gispro.gishub.org
   repository: https://github.com/giswqs/intro-gispro
@@ -151,3 +151,10 @@
   image: https://eecs245.org/assets/site-images/logo.png
   description: An introduction to linear algebra in the context of machine learning, with some statistics, calculus, and Python sprinkled in.
   tags: Education; Machine Learning; Linear Algebra; Calculus; Statistics; Mathematics
+
+- name: UC OSPO Network
+  website: https://ucospo.net/
+  repository: https://github.com/UC-OSPO-Network/ucospo.net
+  image: https://raw.githubusercontent.com/UC-OSPO-Network/ucospo.net/refs/heads/main/static/images/logo.svg
+  description: The official website of the University of California Network of Open Source Program Offices (OSPOs).
+  tags: University of California; Education


### PR DESCRIPTION
Hello, I am adding the UC OSPO Network's website to the JupyterBook Gallery (even though it's not technically a JupyterBook, it's Myst but I'm told that's close enough).

FYI: when I tried to preview the website locally with `myst start`, I just saw a gallery with no entries:
<img width="1331" height="804" alt="Screenshot 2026-05-19 at 1 33 56 PM" src="https://github.com/user-attachments/assets/a21dbd14-642f-426c-b101-38fec4a596ec" />
Not sure if I'm doing something wrong. Anyway, I don't really need the local preview, I just thought I'd let you know.

Also, my formatter didn't like that there were a couple of newlines that contained spaces, so it deleted those extra spaces.
